### PR TITLE
Hardcode ESP8266 runtime tool version identifier

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -363,7 +363,7 @@ export function activate(context: vscode.ExtensionContext) {
         } else if (esp32) {
             tool = findTool(arduinoContext, "runtime.tools.mklittlefs.path");
         } else { // ESP8266
-            tool = findTool(arduinoContext, "runtime.tools.mklittlefs");
+            tool = findTool(arduinoContext, "runtime.tools.mklittlefs-3.1.0-gcc10.3-e5f9fec.path");
         }
         if (tool) {
             mklittlefs = tool + path.sep + mklittlefs;


### PR DESCRIPTION
Fixes #108

Hardcode the last released version string of the mklittlefs tool to avoid issues when ESP32 and ESP8266 cores installed.