### PR TITLE
Handle backslashes in image file path on Windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -500,6 +500,7 @@ async function doOperation(context: vscode.ExtensionContext, arduinoContext: Ard
             }
             if (platform() === 'win32') {
                 imageFile = imageFile.replace(/\\/g, '/') // #117, OpenOCD on Windows seems to parse \s in name as escape chars
+                openocdPath ??= "" // In case it's undefined, make sure we can string.replace
                 openocdPath = openocdPath.replace(/\\/g, '/')
             }
             uploadOpts = ["-f", "interface/cmsis-dap.cfg", "-f", "target/" + chip +".cfg", "-s", openocdPath + "/share/openocd/scripts",


### PR DESCRIPTION
Fix path handling for OpenOCD on Windows.

Fixes #117