### PR TITLE
Manually escape spaces and backslashes for OpenOCD image path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as quote from 'shell-quote';
 import type { ArduinoContext, BoardDetails } from 'vscode-arduino-api';
 import { platform } from 'node:os';
 import { spawn } from 'child_process';
@@ -499,7 +498,7 @@ async function doOperation(context: vscode.ExtensionContext, arduinoContext: Ard
             if (arduinoContext.boardDetails.buildProperties['build.chip']) {
                 chip = arduinoContext.boardDetails.buildProperties['build.chip'];
             }
-            imageFile = quote.quote([imageFile])
+            imageFile = imageFile.replace(/\\/g, "\\\\").replace(/ /g, "\\ ")
             uploadOpts = ["-f", "interface/cmsis-dap.cfg", "-f", "target/" + chip +".cfg", "-s", openocdPath + "/share/openocd/scripts",
                           "-c", "init; adapter speed 5000; program "+ imageFile + " verify 0x" + fsStart.toString(16) + "; reset; exit"];
         } else {


### PR DESCRIPTION
Doesn't seem to be a good existing library to handle
shell escaping.  Because we control the filename, as long
as the temp path only has spaces or backslashes (i..e
username with a space on Windows) OpenOCD
should parse this correctly