### PR TITLE
Use event driven STDERR/STDOUT dumping for tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "arduino-littlefs-upload",
   "displayName": "arduino-littlefs-upload",
   "description": "Build and uploads LittleFS filesystems for the Arduino-Pico RP2040 core, ESP8266 core, or ESP32 core under Arduino IDE 2.2.1 or higher",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "engines": {
     "vscode": "^1.82.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,13 +111,12 @@ function fancyParseInt(str: string) : number {
 // Execute a command and display it's output in the terminal
 async function runCommand(exe : string, opts : any[]) {
     const cmd = spawn(exe, opts);
-    for await (const chunk of cmd.stdout) {
+    cmd.stdout.on('data', function(chunk) {
         writeEmitter.fire(String(chunk).replace(/\n/g, "\r\n"));
-    }
-    for await (const chunk of cmd.stderr) {
-        // Write stderr in red
+    });
+    cmd.stderr.on('data', function(chunk) {
         writeEmitter.fire("\x1b[31m" + String(chunk).replace(/\n/g, "\r\n") + "\x1b[0m");
-    }
+    });
     // Wait until the executable finishes
     let exitCode = await new Promise( (resolve, reject) => {
         cmd.on('close', resolve);


### PR DESCRIPTION
ESPOTA seems very talkative and can hang when uploading massive filesystems because the stderr buffer fills up and blocks further writes.

Use an event driven methos to copy all command outputs instead of a sequential iteration of out then err.

Fixes #124